### PR TITLE
Tried to reduce lines of code and Mega Mann checks

### DIFF
--- a/tf/addons/sourcemod/scripting/fortress_blast.sp
+++ b/tf/addons/sourcemod/scripting/fortress_blast.sp
@@ -12,7 +12,7 @@
 
 int powerupid[MAX_EDICTS];
 int powerup[MAXPLAYERS + 1] = 0;
-int PlayerParticle[MAXPLAYERS + 1][MAX_PARTICLES+1];
+int PlayerParticle[MAXPLAYERS + 1][MAX_PARTICLES + 1];
 int SpeedRotationsLeft[MAXPLAYERS + 1] = 80;
 int MegaMannRotation[MAXPLAYERS + 1] = 0;
 bool PreviousAttack3[MAXPLAYERS + 1] = false;
@@ -24,7 +24,7 @@ bool TimeTravel[MAXPLAYERS + 1] = true;
 float OldSpeed[MAXPLAYERS + 1] = 0.0;
 float SuperSpeed[MAXPLAYERS + 1] = 0.0;
 float VerticalVelocity[MAXPLAYERS + 1];
-float MegaMannCoords[MAXPLAYERS+1][1000][3];
+float MegaMannCoords[MAXPLAYERS + 1][3];
 Handle SuperBounceHandle[MAXPLAYERS + 1];
 Handle ShockAbsorberHandle[MAXPLAYERS + 1];
 Handle GyrocopterHandle[MAXPLAYERS + 1];
@@ -51,35 +51,35 @@ public OnPluginStart() {
 	HookEvent("player_death", player_death);
 	RegConsoleCmd("sm_setpowerup", SetPowerup);
 	RegConsoleCmd("sm_fortressblast", FBMenu);
+	CreateConVar("sm_fortressblast_action_use", "attack3", "Which action to watch for in order to use powerups.");
 	CreateConVar("sm_fortressblast_bot", "1", "Disable or enable bots using powerups.");
 	CreateConVar("sm_fortressblast_bot_min", "2", "Minimum time for bots to use a powerup.");
 	CreateConVar("sm_fortressblast_bot_max", "15", "Maximum time for bots to use a powerup.");
-	CreateConVar("sm_fortressblast_debug", "0", "Disable or enable debug messages in chat.");
+	CreateConVar("sm_fortressblast_debug", "0", "Disable or enable command permission overrides and debug messages in chat.");
 	CreateConVar("sm_fortressblast_drop", "1", "How to handle dropping powerups on death.");
 	CreateConVar("sm_fortressblast_drop_rate", "5", "Chance out of 100 for a powerup to drop on death.");
 	CreateConVar("sm_fortressblast_drop_teams", "1", "Set the teams that will drop powerups on death.");
 	CreateConVar("sm_fortressblast_mannpower", "2", "How to handle replacing Mannpower powerups.");
-	CreateConVar("sm_fortressblast_powerup_button", "attack3", "Button that activates powerups");
 	PrecacheModel("models/props_halloween/pumpkin_loot.mdl");
 	LoadTranslations("common.phrases");
 }
 
 public OnMapStart() {
 	PrecacheSound("fortressblast2/superbounce_pickup.mp3");
-	PrecacheSound("fortressblast2/shockabsorber_pickup.mp3");
-	PrecacheSound("fortressblast2/superspeed_pickup.mp3");
-	PrecacheSound("fortressblast2/superjump_pickup.mp3");
-	PrecacheSound("fortressblast2/gyrocopter_pickup.mp3");
-	PrecacheSound("fortressblast2/timetravel_pickup.mp3");
-	PrecacheSound("fortressblast2/blast_pickup.mp3");
-	PrecacheSound("fortressblast2/megamann_pickup.mp3");
 	PrecacheSound("fortressblast2/superbounce_use.mp3");
+	PrecacheSound("fortressblast2/shockabsorber_pickup.mp3");
 	PrecacheSound("fortressblast2/shockabsorber_use.mp3");
+	PrecacheSound("fortressblast2/superspeed_pickup.mp3");
 	PrecacheSound("fortressblast2/superspeed_use.mp3");
+	PrecacheSound("fortressblast2/superjump_pickup.mp3");
 	PrecacheSound("fortressblast2/superjump_use.mp3");
+	PrecacheSound("fortressblast2/gyrocopter_pickup.mp3");
 	PrecacheSound("fortressblast2/gyrocopter_use.mp3");
+	PrecacheSound("fortressblast2/timetravel_pickup.mp3");
 	PrecacheSound("fortressblast2/timetravel_use.mp3");
+	PrecacheSound("fortressblast2/blast_pickup.mp3");
 	PrecacheSound("fortressblast2/blast_use.mp3");
+	PrecacheSound("fortressblast2/megamann_pickup.mp3");
 	PrecacheSound("fortressblast2/megamann_use.mp3");
 	AddFileToDownloadsTable("sound/fortressblast2/superbounce_pickup.mp3");
 	AddFileToDownloadsTable("sound/fortressblast2/superbounce_use.mp3");
@@ -112,8 +112,8 @@ public TF2_OnConditionAdded(int client, TFCond condition) {
 }
 
 public Action FBMenu(int client, int args) {
-	AdvMOTD_ShowMOTDPanel(client, "How are you reading this?", "http://fortress-blast.github.io/0.3", MOTDPANEL_TYPE_URL, true, true, true, INVALID_FUNCTION);
-	CPrintToChat(client, "{orange}[Fortress Blast] {haunted}Opening Fortress Blast manual... If nothing happens, {yellow}try setting cl_disablehtmlmotd to 0 in the console");
+	AdvMOTD_ShowMOTDPanel(client, "How are you reading this?", "http://fortress-blast.github.io/0.4", MOTDPANEL_TYPE_URL, true, true, true, INVALID_FUNCTION);
+	CPrintToChat(client, "{orange}[Fortress Blast] {haunted}Opening Fortress Blast manual... If nothing happens, open your developer console and {yellow}try setting cl_disablehtmlmotd to 0{haunted}, then try again.");
 }
 
 public Action SetPowerup(int client, int args) {
@@ -133,16 +133,14 @@ public Action SetPowerup(int client, int args) {
 			}
 		}
 		return;
-	}
-	if (StrEqual(arg, "@red")) {
+	} else if (StrEqual(arg, "@red")) {
 		for (int client2 = 1; client2 <= MaxClients; client2++) {
 			if (IsClientInGame(client2) && GetClientTeam(client2) == 2) {
 				FakeClientCommand(client, "sm_setpowerup #%d %d", GetClientUserId(client2), StringToInt(arg2));
 			}
 		}
 		return;
-	}
-	if (StrEqual(arg, "@blue")) {
+	} else if (StrEqual(arg, "@blue")) {
 		for (int client2 = 1; client2 <= MaxClients; client2++) {
 			if (IsClientInGame(client2) && GetClientTeam(client2) == 3) {
 				FakeClientCommand(client, "sm_setpowerup #%d %d", GetClientUserId(client2), StringToInt(arg2));
@@ -193,7 +191,7 @@ public Action teamplay_round_start(Event event, const char[] name, bool dontBroa
 							coords[2] += 8;
 							DebugText("Spawning a powerup at %f %f %f", coords[0], coords[1], coords[2]);
 							SpawnPower(coords, true);
-							}
+						}
 						RemoveEntity(entity);
 					}
 				}
@@ -209,7 +207,7 @@ public Action teamplay_round_start(Event event, const char[] name, bool dontBroa
 
 public Action PesterThisDude(Handle timer, int client) {
 	if (IsClientInGame(client)) { // Required because player might disconnect before this fires
-		CPrintToChat(client, "{orange}[Fortress Blast] {haunted}This server is running {yellow}Fortress Blast v0.3! {haunted}If you would like to know more or are unsure what a powerup does, type the command {yellow}!fortressblast {haunted}into chat.");
+		CPrintToChat(client, "{orange}[Fortress Blast] {haunted}This server is running {yellow}Fortress Blast v0.4! {haunted}If you would like to know more or are unsure what a powerup does, type the command {yellow}!fortressblast {haunted}into chat.");
 	}
 }
 
@@ -259,7 +257,7 @@ SpawnPower(float location[3], bool respawn) {
 		} else if (powerupid[entity] == 7) {
 			SetEntityRenderColor(entity, 50, 177, 177, 255);
 		} else if (powerupid[entity] == 8) {
-			SetEntityRenderColor(entity, 0, 0, 0, 255);
+			SetEntityRenderColor(entity, 100, 50, 50, 255);
 		}
 		DispatchKeyValue(entity, "pickup_sound", "get_out_of_the_console_snoop");
 		DispatchKeyValue(entity, "pickup_particle", "get_out_of_the_console_snoop");
@@ -296,10 +294,10 @@ public Action OnStartTouchDontRespawn(entity, other) {
 	DeletePowerup(entity, other);
 }
 
-DeletePowerup (int entity, other) {
+DeletePowerup(int entity, other) {
 	RemoveEntity(entity);
 	powerup[other] = powerupid[entity];
-	DebugText("%N has collected powerup ID #%d", other, powerup[other]);
+	DebugText("%N has collected powerup ID %d", other, powerup[other]);
 	PlayPowerupSound(other);
 	// If player is a bot and bot support is enabled
 	if (IsFakeClient(other) && GetConVarFloat(FindConVar("sm_fortressblast_bot")) >= 1) { // Replace with GetConVarBool
@@ -355,23 +353,22 @@ PlayPowerupSound(int client) {
 }
 
 public Action OnPlayerRunCmd(int client, int &buttons, int &impulse, float vel[3], float ang[3], int &weapon) {
-	if (GetConVarFloat(FindConVar("sm_fortressblast_debug")) >= 1) {
-		if(GetEntityFlags(client) & FL_ONGROUND){
+	/* if (GetConVarFloat(FindConVar("sm_fortressblast_debug")) >= 1) {
+		if (GetEntityFlags(client) & FL_ONGROUND) {
 			PrintCenterText(client, "Ground");
-		}
-		else{
+		} else {
 			PrintCenterText(client, "Air");
 		}
-	}
+	} */
 	float coords[3] = 69.420;
 	GetEntPropVector(client, Prop_Send, "m_vecOrigin", coords);
 	if (TimeTravel[client]) {
 		SetEntPropFloat(client, Prop_Send, "m_flMaxspeed", 520.0);
 	}
-	if(buttons & 33554432 && (!PreviousAttack3[client]) && StringButtonInt() != 33554432){
+	if (buttons & 33554432 && (!PreviousAttack3[client]) && StringButtonInt() != 33554432) {
 		char button[40];
-		GetConVarString(FindConVar("sm_fortressblast_powerup_button"), button, sizeof(button));
-		CPrintToChat(client, "{orange}[Fortress Blast] {default}On this server, the Powerup Button has moved to %s", button);
+		GetConVarString(FindConVar("sm_fortressblast_action_use"), button, sizeof(button));
+		CPrintToChat(client, "{orange}[Fortress Blast] {red}Special attack is currerntly disabled on this server. You are required to {yellow}perform the '%s' action to use a powerup.", button);
 	}
 	if (buttons & StringButtonInt() && IsPlayerAlive(client)) {
 		UsePower(client);
@@ -397,20 +394,19 @@ public Action OnPlayerRunCmd(int client, int &buttons, int &impulse, float vel[3
 		}
 	}
 	PreviousAttack3[client] = (buttons > 33554431);
-	if(MegaMannRotation[client] > 0){
-		DebugText("%N rotation is %d", client, MegaMannRotation[client]);
-		MegaMannCoords[client][MegaMannRotation[client]][0] = coords[0];
-		MegaMannCoords[client][MegaMannRotation[client]][1] = coords[1];
-		MegaMannCoords[client][MegaMannRotation[client]][2] = coords[2];
-		if(MegaMannRotation[client] > 101){
-			if(MegaMannCoords[client][MegaMannRotation[client]][0] == MegaMannCoords[client][MegaMannRotation[client] - 100][0]){
-				if(MegaMannCoords[client][MegaMannRotation[client]][1] == MegaMannCoords[client][MegaMannRotation[client] - 100][1]){
-					if(MegaMannCoords[client][MegaMannRotation[client]][2] == MegaMannCoords[client][MegaMannRotation[client] - 100][2]){
-						TF2_RespawnPlayer(client);
-						MegaMannRotation[client] = -5;
-						CPrintToChat(client, "{orange}[Fortress Blast]{default} Since you have not moved in a while, we have respawned you to avoid being stuck");
-					}
-				}
+	// Mega Mann stuck-checking loop
+	if (MegaMannRotation[client] > 0) {
+		if (MegaMannRotation[client] == 1) { // Store co-ordinates on powerup use
+			MegaMannCoords[client][0] = coords[0];
+			MegaMannCoords[client][1] = coords[1];
+			MegaMannCoords[client][2] = coords[2];
+		} else if (MegaMannRotation[client] == 102) {
+			// Are co-ordinates the same since powerup use?
+			if (MegaManCoords[client][0] == coords[0] && MegaManCoords[client][1] == coords[1] && MegaManCoords[client][2] == coords[2]) {
+				// Force respawn the player
+				TF2_RespawnPlayer(client);
+				MegaMannRotation[client] = -5;
+				CPrintToChat(client, "{orange}[Fortress Blast] {red}You were respawned since you may have been stuck. Be sure to {yellow}use Mega Mann in open areas {red}and {yellow}move once it is active.");
 			}
 		}
 		MegaMannRotation[client]++;
@@ -503,20 +499,22 @@ UsePower(client) {
 		AcceptEntityInput(client, "SetModelScale");
 		SetEntityHealth(client, (GetClientHealth(client) * 4));
 		ClearTimer(MegaMannHandle[client]);
-		MegaMannRotation[client] = 1;
+		MegaMannRotation[client] = 1; // Activate Mega Mann stuck-checking loop
 		MegaMannHandle[client] = CreateTimer(10.0, RemoveMegaMann, client);
 	}
 	powerup[client] = 0;
 }
+
 public Action RemoveMegaMann(Handle timer, int client) {
 	MegaMannRotation[client] = 0;
 	MegaMannHandle[client] = INVALID_HANDLE;
 	SetVariantString("1 0");
 	AcceptEntityInput(client, "SetModelScale");
-	if(GetClientHealth(client) > TF2_GetPlayerMaxHealth(client)){
+	if (GetClientHealth(client) > TF2_GetPlayerMaxHealth(client)) {
 		SetEntityHealth(client, TF2_GetPlayerMaxHealth(client));
 	}
 }
+
 public Action RemoveTimeTravel(Handle timer, int client) {
 	TimeTravelHandle[client] = INVALID_HANDLE;
 	TimeTravel[client] = false;
@@ -759,83 +757,60 @@ DebugText(const char[] text, any ...) {
 
 int StringButtonInt() {
 	char button[40];
-	GetConVarString(FindConVar("sm_fortressblast_powerup_button"), button, sizeof(button));
+	GetConVarString(FindConVar("sm_fortressblast_action_use"), button, sizeof(button));
 	if (StrEqual(button, "attack")) {
-			return 1;
-	}
-	if (StrEqual(button, "jump")) {
+		return 1;
+	} else if (StrEqual(button, "jump")) {
 		return 2;
-	}
-	if (StrEqual(button, "duck")) {
+	} else if (StrEqual(button, "duck")) {
 		return 4;
-	}
-	if (StrEqual(button, "forward")) {	
+	} else if (StrEqual(button, "forward")) {	
 		return 8;
-	}
-	if (StrEqual(button, "back")) {
+	} else if (StrEqual(button, "back")) {
 		return 16;
-	}
-	if (StrEqual(button, "use")) {
+	} else if (StrEqual(button, "use")) {
 		return 32;
-	}
-	if (StrEqual(button, "cancel")) {
+	} else if (StrEqual(button, "cancel")) {
 		return 64;
-	}
-	if (StrEqual(button, "left")) {
+	} else if (StrEqual(button, "left")) {
 		return 128;
-	}
-	if (StrEqual(button, "right")) {
+	} else if (StrEqual(button, "right")) {
 		return 256;
-	}
-	if (StrEqual(button, "moveleft")) {
+	} else if (StrEqual(button, "moveleft")) {
 		return 512;
-	}
-	if (StrEqual(button, "moveright")) {
+	} else if (StrEqual(button, "moveright")) {
 		return 1024;
-	}
-	if (StrEqual(button, "attack2")) {
+	} else if (StrEqual(button, "attack2")) {
 		return 2048;
-	}
-	if (StrEqual(button, "run")) {
+	} else if (StrEqual(button, "run")) {
 		return 4096;
-	}
-	if (StrEqual(button, "reload")) {
+	} else if (StrEqual(button, "reload")) {
 		return 8192;
-	}
-	if (StrEqual(button, "alt1")) {
+	} else if (StrEqual(button, "alt1")) {
 		return 16384;
-	}
-	if (StrEqual(button, "alt2")) {
+	} else if (StrEqual(button, "alt2")) {
 		return 32768;
-	}
-	if (StrEqual(button, "score")) {
+	} else if (StrEqual(button, "score")) {
 		return 65536;
-	}
-	if (StrEqual(button, "speed")) {
+	} else if (StrEqual(button, "speed")) {
 		return 131072;
-	}
-	if (StrEqual(button, "walk")) {
+	} else if (StrEqual(button, "walk")) {
 		return 262144;
-	}
-	if (StrEqual(button, "zoom")) {
+	} else if (StrEqual(button, "zoom")) {
 		return 524288;
-	}
-	if (StrEqual(button, "weapon1")) {
+	} else if (StrEqual(button, "weapon1")) {
 		return 1048576;
-	}
-	if (StrEqual(button, "weapon2")) {
+	} else if (StrEqual(button, "weapon2")) {
 		return 2097152;
-	}
-	if (StrEqual(button, "bullrush")) {
+	} else if (StrEqual(button, "bullrush")) {
 		return 4194304;
-	}
-	if (StrEqual(button, "grenade1")) {
+	} else if (StrEqual(button, "grenade1")) {
 		return 8388608;
-	}
-	if (StrEqual(button, "grenade2")) {
+	} else if (StrEqual(button, "grenade2")) {
 		return 16777216;
+	} else { // Special attack
+		return 33554432;
 	}
-	return 33554432;
 }
 
 stock int TF2_GetPlayerMaxHealth(int client) {


### PR DESCRIPTION
This pull request is likely highly unstable because it changes the inner workings of the Mega Mann powerup co-ordinates checking. My main focus was reducing the number of lines of code overall, and one way I did this was by reducing the time Mega Mann spends checking for co-ordinates. Now it's only one tick. See if this works.